### PR TITLE
refactor(preflight): fold the stale-BCD guards into Where and Select

### DIFF
--- a/src/Igloo.Preflight/DirectInstallService.cs
+++ b/src/Igloo.Preflight/DirectInstallService.cs
@@ -1535,18 +1535,12 @@ public sealed partial class DirectInstallService : IDirectInstallService
         if (string.IsNullOrEmpty(listing))
             return [];
 
-        var ids = new List<string>();
-        foreach (var block in Regex.Split(listing, @"\r?\n[ \t]*\r?\n"))
-        {
-            if (!block.Contains(description, StringComparison.Ordinal))
-                continue;
-
-            var id = Regex.Match(block, @"^identifier\s+(\{[0-9a-fA-F-]{36}\})",
-                                 RegexOptions.Multiline).Groups[1].Value;
-            if (id.Length > 0)
-                ids.Add(id);
-        }
-        return ids;
+        return Regex.Split(listing, @"\r?\n[ \t]*\r?\n")
+            .Where(block => block.Contains(description, StringComparison.Ordinal))
+            .Select(block => Regex.Match(block, @"^identifier\s+(\{[0-9a-fA-F-]{36}\})",
+                                         RegexOptions.Multiline).Groups[1].Value)
+            .Where(id => id.Length > 0)
+            .ToList();
     }
 
     private string? RunBcdedit(string arguments)


### PR DESCRIPTION
## What and why

`ParseStaleBcdIds` built its result with an accumulator list and two guards
inside a `foreach`. It now reads as the pipeline it always was: split the
`bcdedit` listing on blank lines, keep the blocks naming the loader we are
looking for, pull the identifier out, drop the ones that did not match.

Resolves CodeQL `cs/linq/missed-where` (#303).

Behaviour is unchanged, including the CRLF handling the `<remarks>` block
warns about - that regex is untouched.

## Checklist

- [x] `dotnet build Igloo.sln` is clean - no new warnings, no suppressions added
      (verified with `-warnaserror` and `AnalysisMode=All`: 0 warnings)
- [x] `dotnet test Igloo.sln` is green; new behavior has a test
      (`StaleBcdEntryParsingTests`, 6 tests, already existed and still pass)
- [x] Code matches `.editorconfig` and the surrounding style.
- [x] Commits are signed off (DCO).

## Safety-critical paths

- [ ] **Touched the install / removal pipeline, first-boot agents, boot entries,
      or ISO verification** -> I ran a real end-to-end install in a VM.
  - Not ticked on purpose. This is boot-entry *parsing*, so rule 4 arguably
    applies, but the change is behaviour-preserving and the six existing tests
    pin the output exactly. No VM run was performed. Say the word if you want
    one before this merges.
