### PR TITLE
test(migration): cover the cookie loop, then simplify it

### DIFF
--- a/src/Igloo.Migration/Chromium/ChromiumCredentialExtractor.cs
+++ b/src/Igloo.Migration/Chromium/ChromiumCredentialExtractor.cs
@@ -119,7 +119,7 @@ public static partial class ChromiumCredentialExtractor
     /// failure here is logged and skipped rather than allowed to cost the
     /// passwords that come from the same profile.
     /// </summary>
-    private static void ExtractCookies(
+    internal static void ExtractCookies(
         byte[] masterKey, string profileDir, List<ChromiumCookie> cookies, ILogger logger)
     {
         var cookiesPath = CookieDataReader.Locate(profileDir);

--- a/src/Igloo.Migration/Chromium/ChromiumCredentialExtractor.cs
+++ b/src/Igloo.Migration/Chromium/ChromiumCredentialExtractor.cs
@@ -138,12 +138,10 @@ public static partial class ChromiumCredentialExtractor
             return;
         }
 
-        foreach (var row in rows)
+        // v20 (App-Bound) cookies are skipped for the same reason v20 passwords
+        // are; the rest of the jar still migrates.
+        foreach (var row in rows.Where(r => Classify(r.EncryptedValue.Span) == EntryKind.V10))
         {
-            // v20 (App-Bound) cookies are skipped for the same reason v20
-            // passwords are; the rest of the jar still migrates.
-            if (Classify(row.EncryptedValue.Span) != EntryKind.V10)
-                continue;
             if (TryDecryptV10Bytes(masterKey, row.EncryptedValue.Span, out var value))
                 cookies.Add(new ChromiumCookie(row.HostKey, row.Name, row.Path, value));
         }

--- a/src/Igloo.Migration/Igloo.Migration.csproj
+++ b/src/Igloo.Migration/Igloo.Migration.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Igloo.Migration.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Igloo.Core\Igloo.Core.csproj" />
   </ItemGroup>
 

--- a/tests/Igloo.Migration.Tests/Chromium/ExtractCookiesTests.cs
+++ b/tests/Igloo.Migration.Tests/Chromium/ExtractCookiesTests.cs
@@ -1,0 +1,135 @@
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
+using FluentAssertions;
+using Igloo.Migration.Chromium;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Igloo.Migration.Tests.Chromium;
+
+/// <summary>
+/// Covers the cookie loop itself, not just the pieces it calls. The building
+/// blocks each had a test; the loop that decides which rows survive did not.
+/// </summary>
+public sealed class ExtractCookiesTests : IDisposable
+{
+    private readonly byte[] _key = Convert.FromHexString(
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f");
+
+    private readonly string _profile = Path.Join(
+        Path.GetTempPath(), $"igloo-cookieprofile-{Guid.NewGuid():N}");
+
+    public ExtractCookiesTests() => Directory.CreateDirectory(_profile);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_profile, recursive: true); }
+        catch (IOException ex) { Debug.WriteLine($"Temp cleanup failed for {_profile}: {ex.Message}"); }
+    }
+
+    // "v10" || nonce (12) || ciphertext || tag (16), AES-256-GCM - the shape
+    // TryDecryptV10Bytes expects.
+    private byte[] V10Blob(byte[] plaintext, byte[]? key = null)
+    {
+        var nonce = RandomNumberGenerator.GetBytes(12);
+        var ciphertext = new byte[plaintext.Length];
+        var tag = new byte[16];
+        using (var gcm = new AesGcm(key ?? _key, 16))
+            gcm.Encrypt(nonce, plaintext, ciphertext, tag);
+        return [.. "v10"u8.ToArray(), .. nonce, .. ciphertext, .. tag];
+    }
+
+    private void WriteCookieDb(params (string Host, string Name, string Path, byte[] Value)[] rows)
+    {
+        using var connection = new SqliteConnection(
+            $"Data Source={Path.Join(_profile, "Cookies")}");
+        connection.Open();
+
+        using (var create = connection.CreateCommand())
+        {
+            create.CommandText =
+                "CREATE TABLE cookies (host_key TEXT, name TEXT, path TEXT, encrypted_value BLOB);";
+            create.ExecuteNonQuery();
+        }
+
+        foreach (var (host, name, path, value) in rows)
+        {
+            using var insert = connection.CreateCommand();
+            insert.CommandText = "INSERT INTO cookies VALUES ($h, $n, $p, $v);";
+            insert.Parameters.AddWithValue("$h", host);
+            insert.Parameters.AddWithValue("$n", name);
+            insert.Parameters.AddWithValue("$p", path);
+            insert.Parameters.AddWithValue("$v", value);
+            insert.ExecuteNonQuery();
+        }
+    }
+
+    private List<ChromiumCookie> Extract()
+    {
+        var cookies = new List<ChromiumCookie>();
+        ChromiumCredentialExtractor.ExtractCookies(_key, _profile, cookies, NullLogger.Instance);
+        return cookies;
+    }
+
+    [Fact]
+    public void V10Cookie_ArrivesWithItsIdentityAndPlaintext()
+    {
+        // Bytes, not text: Chromium prefixes the plaintext with a domain hash,
+        // so the value has to survive the round trip untouched.
+        var plaintext = Encoding.UTF8.GetBytes("session=abc123");
+        WriteCookieDb(("example.com", "session", "/", V10Blob(plaintext)));
+
+        var cookies = Extract();
+
+        cookies.Should().ContainSingle();
+        cookies[0].HostKey.Should().Be("example.com");
+        cookies[0].Name.Should().Be("session");
+        cookies[0].Path.Should().Be("/");
+        cookies[0].Value.ToArray().Should().Equal(plaintext);
+    }
+
+    [Fact]
+    public void V20Cookie_IsSkippedWithoutCostingTheRestOfTheJar()
+    {
+        var keep = Encoding.UTF8.GetBytes("keep=me");
+        WriteCookieDb(
+            ("a.example", "appbound", "/",
+                [.. "v20"u8.ToArray(), .. RandomNumberGenerator.GetBytes(40)]),
+            ("b.example", "keep", "/", V10Blob(keep)));
+
+        var cookies = Extract();
+
+        cookies.Should().ContainSingle();
+        cookies[0].Name.Should().Be("keep");
+        cookies[0].Value.ToArray().Should().Equal(keep);
+    }
+
+    [Fact]
+    public void LegacyDpapiCookie_IsSkipped()
+    {
+        WriteCookieDb(("a.example", "old", "/", [1, 2, 3, 4, 5, 6, 7, 8]));
+
+        Extract().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void V10Cookie_UnderAnotherKey_IsSkipped()
+    {
+        var stranger = RandomNumberGenerator.GetBytes(32);
+        WriteCookieDb(("a.example", "c", "/",
+            V10Blob(Encoding.UTF8.GetBytes("nope"), stranger)));
+
+        Extract().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void MissingCookieDatabase_AddsNothingAndDoesNotThrow()
+    {
+        var act = Extract;
+
+        act.Should().NotThrow();
+        Extract().Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## What and why

The cookie loop in `ExtractCookies` had no test. Its building blocks did -
`GetMasterKey` (4), `CookieDataReader.Read` (1), `TryDecryptV10Bytes` (2) - but
nothing exercised the loop that decides which rows survive.

Two commits, in this order on purpose:

1. **test** - five tests over the loop itself, run against the *unrefactored*
   code first so they pin existing behaviour rather than the new shape.
2. **refactor** - the classification guard moves into the `foreach` header,
   resolving CodeQL `cs/linq/missed-where`. The `TryDecryptV10Bytes` call stays
   an `if`: it is a Try-pattern that both filters and produces, and forcing it
   into a `Select` reads worse than the guard it replaces.

What the tests lock down:

- a v10 cookie arrives with its host, name, path and plaintext **as bytes** -
  Chromium prefixes the plaintext with a domain hash, so a string round trip
  would corrupt it
- a v20 (App-Bound) cookie is skipped without costing the v10 row beside it in
  the same jar - the exact branch the refactor touches
- a legacy DPAPI blob is skipped
- a v10 blob under another key is skipped (GCM tag check fails)
- a missing `Cookies` database adds nothing and does not throw

`ExtractCookies` went from `private` to `internal`, and `Igloo.Migration` gained
`<InternalsVisibleTo Include="Igloo.Migration.Tests" />` - the same pattern
App, Iso, Preflight and UsbWriter already use. Migration was the only project
without it.

## Checklist

- [x] `dotnet build Igloo.sln` is clean - no new warnings, no suppressions added
      (verified with `-warnaserror`: 0 warnings)
- [x] `dotnet test Igloo.sln` is green; new behavior has a test
      (5 new; 25 pass in Igloo.Migration.Tests)
- [x] Code matches `.editorconfig` and the surrounding style.
- [x] Commits are signed off (DCO).

## Safety-critical paths

- [ ] **Touched the install / removal pipeline, first-boot agents, boot entries,
      or ISO verification** -> I ran a real end-to-end install in a VM.
  - Not ticked on purpose. This is the credential migration path, which
    SECURITY.md puts in scope, so it deserves the flag. The change is
    behaviour-preserving and now has test coverage it did not have before, but
    no VM run was performed.
